### PR TITLE
Fix class static variables

### DIFF
--- a/include/clang/Interpreter/InterOp.h
+++ b/include/clang/Interpreter/InterOp.h
@@ -24,6 +24,8 @@ namespace InterOp {
   typedef void (*CallFuncWrapper_t)(void*, int, void**, void*);
 
   bool IsNamespace(TCppScope_t scope);
+
+  bool IsClass(TCppScope_t scope);
   // See TClingClassInfo::IsLoaded
   bool IsComplete(TCppScope_t scope);
 

--- a/lib/Interpreter/InterOp.cpp
+++ b/lib/Interpreter/InterOp.cpp
@@ -41,6 +41,11 @@ namespace InterOp {
     Decl *D = static_cast<Decl*>(scope);
     return isa<NamespaceDecl>(D);
   }
+
+  bool IsClass(TCppScope_t scope) {
+    Decl *D = static_cast<Decl*>(scope);
+    return isa<CXXRecordDecl>(D);
+  }
   // See TClingClassInfo::IsLoaded
   bool IsComplete(TCppScope_t scope) {
     if (!scope)

--- a/unittests/InterOp/ScopeReflectionTest.cpp
+++ b/unittests/InterOp/ScopeReflectionTest.cpp
@@ -24,6 +24,14 @@ TEST(ScopeReflectionTest, IsNamespace) {
   EXPECT_FALSE(InterOp::IsNamespace(Decls[2]));
 }
 
+TEST(ScopeReflectionTest, IsClass) {
+  std::vector<Decl*> Decls;
+  GetAllTopLevelDecls("namespace N {} class C{}; int I;", Decls);
+  EXPECT_FALSE(InterOp::IsClass(Decls[0]));
+  EXPECT_TRUE(InterOp::IsClass(Decls[1]));
+  EXPECT_FALSE(InterOp::IsClass(Decls[2]));
+}
+
 TEST(ScopeReflectionTest, IsComplete) {
   std::vector<Decl*> Decls;
   GetAllTopLevelDecls("namespace N {} class C{}; int I; struct S; enum E : int; union U{};",

--- a/unittests/InterOp/VariableReflectionTest.cpp
+++ b/unittests/InterOp/VariableReflectionTest.cpp
@@ -102,10 +102,13 @@ TEST(VariableReflectionTest, GetVariableOffset) {
       double b;
       int *c;
       int d;
+
+      static int s_a;
     };
+    int C::s_a = 12;
     )";
 
-  class {
+  class C{
   public:
     int a;
     double b;
@@ -117,8 +120,7 @@ TEST(VariableReflectionTest, GetVariableOffset) {
   GetAllTopLevelDecls(code, Decls);
   auto datamembers = InterOp::GetDatamembers(Decls[1]);
 
-  EXPECT_FALSE(InterOp::GetVariableOffset(Interp.get(), Decls[0])
-          == (intptr_t) 0);
+  EXPECT_TRUE((bool) InterOp::GetVariableOffset(Interp.get(), Decls[0]));
 
   EXPECT_EQ(InterOp::GetVariableOffset(Interp.get(), datamembers[0]),
           0);
@@ -128,6 +130,10 @@ TEST(VariableReflectionTest, GetVariableOffset) {
           ((unsigned long) &(c.c)) - ((unsigned long) &(c.a)));
   EXPECT_EQ(InterOp::GetVariableOffset(Interp.get(), datamembers[3]),
           ((unsigned long) &(c.d)) - ((unsigned long) &(c.a)));
+
+  Sema *S = &Interp->getCI()->getSema();
+  auto *VD_C_s_a = InterOp::GetNamed(S, "s_a", Decls[1]); // C::s_a
+  EXPECT_TRUE((bool) InterOp::GetVariableOffset(Interp.get(), VD_C_s_a));
 }
 
 TEST(VariableReflectionTest, IsPublicVariable) {


### PR DESCRIPTION
This PR adds functions that are necessary to fix class static variables in cppyy.

@vgvassilev the address of class static variables is not being returned. Offending lines of code:
https://github.com/compiler-research/InterOp/blob/515ef931fc6db076bc4c414a54e1b24a8c8b2858/lib/Interpreter/InterOp.cpp#L794-L797

The above code returns nullptr. This test case has been added to GetVariableOffset test.