### PR TITLE
Utkarshraj

### DIFF
--- a/unittests/InterOp/FunctionReflectionTest.cpp
+++ b/unittests/InterOp/FunctionReflectionTest.cpp
@@ -653,14 +653,15 @@ TEST(FunctionReflectionTest, DISABLED_GetFunctionArgName) {
     )";
 
   GetAllTopLevelDecls(code, Decls);
-  // EXPECT_EQ(InterOp::GetFunctionArgName(Decls[0], 0), "i");
-  // EXPECT_EQ(InterOp::GetFunctionArgName(Decls[0], 1), "d");
-  // EXPECT_EQ(InterOp::GetFunctionArgName(Decls[0], 2), "l");
-  // EXPECT_EQ(InterOp::GetFunctionArgName(Decls[0], 3), "ch");
-  // EXPECT_EQ(InterOp::GetFunctionArgName(Decls[1], 0), "i");
-  // EXPECT_EQ(InterOp::GetFunctionArgName(Decls[1], 1), "d");
-  // EXPECT_EQ(InterOp::GetFunctionArgName(Decls[1], 2), "l");
-  // EXPECT_EQ(InterOp::GetFunctionArgName(Decls[1], 3), "ch");
+  GetAllSubDecls(Decls[0], SubDecls);
+  EXPECT_EQ(InterOp::GetFunctionArgName(Decls[0], 0), "i");
+  EXPECT_EQ(InterOp::GetFunctionArgName(Decls[0], 1), "d");
+  EXPECT_EQ(InterOp::GetFunctionArgName(Decls[0], 2), "l");
+  EXPECT_EQ(InterOp::GetFunctionArgName(Decls[0], 3), "ch");
+  EXPECT_EQ(InterOp::GetFunctionArgName(Decls[1], 0), "i");
+  EXPECT_EQ(InterOp::GetFunctionArgName(Decls[1], 1), "d");
+  EXPECT_EQ(InterOp::GetFunctionArgName(Decls[1], 2), "l");
+  EXPECT_EQ(InterOp::GetFunctionArgName(Decls[1], 3), "ch");
 }
 
 TEST(FunctionReflectionTest, DISABLED_GetFunctionArgDefault) {
@@ -670,10 +671,10 @@ TEST(FunctionReflectionTest, DISABLED_GetFunctionArgDefault) {
     )";
 
   GetAllTopLevelDecls(code, Decls);
-  // EXPECT_EQ(InterOp::GetFunctionArgDefault(Decls[0], 0), "");
-  // EXPECT_EQ(InterOp::GetFunctionArgDefault(Decls[0], 1), "4.0");
-  // EXPECT_EQ(InterOp::GetFunctionArgDefault(Decls[0], 2), "\"default\"");
-  // EXPECT_EQ(InterOp::GetFunctionArgDefault(Decls[0], 3), "\'c\'");
+  EXPECT_EQ(InterOp::GetFunctionArgDefault(Decls[0], 0), "");
+  EXPECT_EQ(InterOp::GetFunctionArgDefault(Decls[0], 1), "4.0");
+  EXPECT_EQ(InterOp::GetFunctionArgDefault(Decls[0], 2), "\"default\"");
+  EXPECT_EQ(InterOp::GetFunctionArgDefault(Decls[0], 3), "\'c\'");
 }
 
 TEST(FunctionReflectionTest, DISABLED_Construct) {

--- a/unittests/InterOp/TypeReflectionTest.cpp
+++ b/unittests/InterOp/TypeReflectionTest.cpp
@@ -332,7 +332,7 @@ TEST(TypeReflectionTest, DISABLED_IsSubType) {
 
   std::string code = R"(
       class A {};
-      class B : A {};
+      class B {};
       class C {};
 
       A a;
@@ -346,9 +346,9 @@ TEST(TypeReflectionTest, DISABLED_IsSubType) {
   InterOp::TCppType_t type_B = InterOp::GetVariableType(Decls[4]);
   InterOp::TCppType_t type_C = InterOp::GetVariableType(Decls[5]);
 
-  // EXPECT_TRUE(InterOp::IsSubType(type_B, type_A));
-  // EXPECT_FALSE(InterOp::IsSubType(type_A, type_B));
-  // EXPECT_FALSE(InterOp::IsSubType(type_C, type_A));
+  EXPECT_TRUE(InterOp::IsSubType(type_B, type_A));
+  EXPECT_FALSE(InterOp::IsSubType(type_A, type_B));
+  EXPECT_FALSE(InterOp::IsSubType(type_C, type_A));
 }
 
 TEST(TypeReflectionTest, DISABLED_GetDimensions) {


### PR DESCRIPTION
TEST(TypeReflectionTest, DISABLED_IsSubType) {
  std::vector<Decl *> Decls;

  std::string code = R"(
      class A {};
      class B {};
      class C {};

      A a;
      B b;
      C c;
    )";

  GetAllTopLevelDecls(code, Decls);
  
  InterOp::TCppType_t type_A = InterOp::GetVariableType(Decls[3]);
  InterOp::TCppType_t type_B = InterOp::GetVariableType(Decls[4]);
  InterOp::TCppType_t type_C = InterOp::GetVariableType(Decls[5]);

  EXPECT_TRUE(InterOp::IsSubType(type_B, type_A));
  EXPECT_FALSE(InterOp::IsSubType(type_A, type_B));
  EXPECT_FALSE(InterOp::IsSubType(type_C, type_A));
}