### PR TITLE
Add support for ArrayTypes that are not ConstantArrayType in GetDimensions

### DIFF
--- a/include/clang/Interpreter/InterOp.h
+++ b/include/clang/Interpreter/InterOp.h
@@ -200,6 +200,12 @@ namespace InterOp {
 
   void DumpScope(TCppScope_t scope);
 
+  namespace DimensionValue {
+    enum : long int {
+      UNKNOWN_SIZE = -1,
+    };
+  }
+
   std::vector<long int> GetDimensions(TCppType_t type);
 } // end namespace InterOp
 

--- a/lib/Interpreter/InterOp.cpp
+++ b/lib/Interpreter/InterOp.cpp
@@ -2215,12 +2215,16 @@ namespace InterOp {
     if (Qual->isArrayType())
     {
       const clang::ArrayType *ArrayType = dyn_cast<clang::ArrayType>(Qual.getTypePtr());
-      while (const auto *CAT = dyn_cast_or_null<ConstantArrayType>(ArrayType))
+      while (ArrayType)
       {
-        llvm::APSInt Size(CAT->getSize());
-        int ArraySize = Size.getLimitedValue();
-        dims.push_back(ArraySize);
-        ArrayType = CAT->getElementType()->getAsArrayTypeUnsafe();
+        if (const auto *CAT = dyn_cast_or_null<ConstantArrayType>(ArrayType)) {
+          llvm::APSInt Size(CAT->getSize());
+          long int ArraySize = Size.getLimitedValue();
+          dims.push_back(ArraySize);
+        } else /* VariableArrayType, DependentSizedArrayType, IncompleteArrayType */ {
+          dims.push_back(DimensionValue::UNKNOWN_SIZE);
+        }
+        ArrayType = ArrayType->getElementType()->getAsArrayTypeUnsafe();
       }
       return dims;
     }

--- a/unittests/InterOp/TypeReflectionTest.cpp
+++ b/unittests/InterOp/TypeReflectionTest.cpp
@@ -384,13 +384,22 @@ TEST(TypeReflectionTest, IsTypeDerivedFrom) {
 }
 
 TEST(TypeReflectionTest, GetDimensions) {
-  std::vector<Decl *> Decls;
+  std::vector<Decl *> Decls, SubDecls;
 
   std::string code = R"(
       int a;
       int b[1];
       int c[1][2];
       int d[1][2][3];
+
+      struct S1 {
+        char ch[];
+      };
+
+
+      struct S2 {
+        char ch[][3][4];
+      };
     )";
 
   GetAllTopLevelDecls(code, Decls);
@@ -427,6 +436,26 @@ TEST(TypeReflectionTest, GetDimensions) {
   // Variable d
   dims = InterOp::GetDimensions(InterOp::GetVariableType(Decls[3]));
   truth_dims = std::vector<long int>({1, 2, 3});
+  EXPECT_EQ(dims.size(), truth_dims.size());
+  for (unsigned i = 0; i < truth_dims.size() && i < dims.size(); i++)
+  {
+    EXPECT_EQ(dims[i], truth_dims[i]);
+  }
+
+  // Field S1::ch
+  GetAllSubDecls(Decls[4], SubDecls);
+  dims = InterOp::GetDimensions(InterOp::GetVariableType(SubDecls[1]));
+  truth_dims = std::vector<long int>({InterOp::DimensionValue::UNKNOWN_SIZE});
+  EXPECT_EQ(dims.size(), truth_dims.size());
+  for (unsigned i = 0; i < truth_dims.size() && i < dims.size(); i++)
+  {
+    EXPECT_EQ(dims[i], truth_dims[i]);
+  }
+
+  // Field S2::ch
+  GetAllSubDecls(Decls[5], SubDecls);
+  dims = InterOp::GetDimensions(InterOp::GetVariableType(SubDecls[3]));
+  truth_dims = std::vector<long int>({InterOp::DimensionValue::UNKNOWN_SIZE, 3, 4});
   EXPECT_EQ(dims.size(), truth_dims.size());
   for (unsigned i = 0; i < truth_dims.size() && i < dims.size(); i++)
   {


### PR DESCRIPTION
Uses an enum `DimensionValue::UNKNOWN_SIZE` to denote the size of these types.

I have used a `namespace` instead of an `enum class` for `DimensionValue` so that it can be implicitly converted to and from long int.