### PR TITLE
Teach InterOp::CreateInterpreter to take arguments.

### DIFF
--- a/include/clang/Interpreter/InterOp.h
+++ b/include/clang/Interpreter/InterOp.h
@@ -176,8 +176,8 @@ namespace InterOp {
 
   /// Returns the argument name of function as string. 
   std::string GetFunctionArgName(TCppFunction_t func, TCppIndex_t param_index);
-    
-  TInterp_t CreateInterpreter(const char *resource_dir = nullptr);
+
+  TInterp_t CreateInterpreter(const std::vector<const char*> &Args = {});
 
   TCppSema_t GetSema(TInterp_t interp);
 

--- a/lib/Interpreter/InterOp.cpp
+++ b/lib/Interpreter/InterOp.cpp
@@ -278,14 +278,10 @@ namespace InterOp {
     auto *S = (Sema *) sema;
     auto *ND = InterOp_utils::Lookup::Named(S, name, Within);
 
-    if (!(ND == (NamedDecl *) -1) &&
-            (llvm::isa_and_nonnull<NamespaceDecl>(ND)     ||
-             llvm::isa_and_nonnull<RecordDecl>(ND)        ||
-             llvm::isa_and_nonnull<ClassTemplateDecl>(ND) ||
-             llvm::isa_and_nonnull<TypedefDecl>(ND)))
-      return (TCppScope_t)(ND->getCanonicalDecl());
+    if (!ND || (ND == (NamedDecl *) -1))
+      return nullptr;
 
-    return 0;
+    return ND->getCanonicalDecl();
   }
 
   TCppScope_t GetScopeFromCompleteName(TCppSema_t sema, const std::string &name)
@@ -2070,13 +2066,14 @@ namespace InterOp {
   }
   }
 
-  TInterp_t CreateInterpreter(const char *resource_dir) {
+  TInterp_t CreateInterpreter(const std::vector<const char*> &Args/*={}*/) {
     std::string MainExecutableName =
       sys::fs::getMainExecutable(nullptr, nullptr);
     std::string ResourceDir = MakeResourcesPath();
     std::vector<const char *> ClingArgv = {"-resource-dir", ResourceDir.c_str(),
                                            "-std=c++14"};
     ClingArgv.insert(ClingArgv.begin(), MainExecutableName.c_str());
+    ClingArgv.insert(ClingArgv.end(), Args.begin(), Args.end());
     return new compat::Interpreter(ClingArgv.size(), &ClingArgv[0]);
   }
 

--- a/unittests/InterOp/CMakeLists.txt
+++ b/unittests/InterOp/CMakeLists.txt
@@ -3,12 +3,13 @@ set(LLVM_LINK_COMPONENTS
   )
 
 add_interop_unittest(InterOpTests
-  Utils.cpp
-  ScopeReflectionTest.cpp
-  FunctionReflectionTest.cpp
-  VariableReflectionTest.cpp
-  TypeReflectionTest.cpp
   EnumReflectionTest.cpp
+  FunctionReflectionTest.cpp
+  InterpreterTest.cpp
+  ScopeReflectionTest.cpp
+  TypeReflectionTest.cpp
+  Utils.cpp
+  VariableReflectionTest.cpp
   )
 
 if (USE_CLING)

--- a/unittests/InterOp/InterpreterTest.cpp
+++ b/unittests/InterOp/InterpreterTest.cpp
@@ -1,0 +1,28 @@
+#include "clang/Interpreter/InterOp.h"
+
+#include "gtest/gtest.h"
+
+TEST(InterpreterTest, CreateInterpreter) {
+  auto I = InterOp::CreateInterpreter();
+  EXPECT_TRUE(I);
+  // Check if the default standard is c++14
+
+  InterOp::Declare(I,
+                   "#if __cplusplus==201402L\n"
+                   "int cpp14() { return 2014; }\n"
+                   "#else\n"
+                   "void cppUnknown() {}\n"
+                   "#endif");
+  EXPECT_TRUE(InterOp::GetScope(InterOp::GetSema(I), "cpp14"));
+  EXPECT_FALSE(InterOp::GetScope(InterOp::GetSema(I), "cppUnknown"));
+
+  I = InterOp::CreateInterpreter({"-std=c++17"});
+  InterOp::Declare(I,
+                   "#if __cplusplus==201703L\n"
+                   "int cpp17() { return 2017; }\n"
+                   "#else\n"
+                   "void cppUnknown() {}\n"
+                   "#endif");
+  EXPECT_TRUE(InterOp::GetScope(InterOp::GetSema(I), "cpp17"));
+  EXPECT_FALSE(InterOp::GetScope(InterOp::GetSema(I), "cppUnknown"));
+}


### PR DESCRIPTION
This patch drops the unused resource-dir parameter and improves the implementation of GetScope allowing it to return more found declarations such as function declarations.