### PR TITLE
IsComplete should try to instantiate a type if it was a template.

### DIFF
--- a/include/clang/Interpreter/InterOp.h
+++ b/include/clang/Interpreter/InterOp.h
@@ -21,7 +21,6 @@ namespace InterOp {
   using TCppFunction_t = void*;
   using TCppConstFunction_t = const void*;
   using TCppFuncAddr_t = void*;
-  using TCppSema_t = void *;
   using TInterp_t = void*;
   using TCppObject_t = void*;
   /// A class modeling function calls for functions produced by the interpreter
@@ -29,7 +28,7 @@ namespace InterOp {
   /// function, constructor or destructor.
   class JitCall {
   public:
-    friend JitCall MakeFunctionCallable(TInterp_t, TCppConstFunction_t);
+    friend JitCall MakeFunctionCallable(TCppConstFunction_t);
     enum Kind : char {
       kUnknown = 0,
       kGenericCall,
@@ -160,29 +159,27 @@ namespace InterOp {
 
   TCppIndex_t GetEnumConstantValue(TCppScope_t scope);
 
-  size_t GetSizeOfType(TCppSema_t sema, TCppType_t type);
+  size_t GetSizeOfType(TCppType_t type);
 
   bool IsVariable(TCppScope_t scope);
 
   std::string GetName(TCppType_t klass);
 
-  std::string GetCompleteName(TCppSema_t sema, TCppType_t klass);
+  std::string GetCompleteName(TCppType_t klass);
 
   std::string GetQualifiedName(TCppType_t klass);
 
-  std::string GetQualifiedCompleteName(TCppSema_t sema, TCppType_t klass);
+  std::string GetQualifiedCompleteName(TCppType_t klass);
 
   std::vector<TCppScope_t> GetUsingNamespaces(TCppScope_t scope);
 
-  TCppScope_t GetGlobalScope(TCppSema_t sema);
+  TCppScope_t GetGlobalScope();
 
-  TCppScope_t GetScope(TCppSema_t sema, const std::string &name,
-                       TCppScope_t parent = 0);
+  TCppScope_t GetScope(const std::string &name, TCppScope_t parent = 0);
 
-  TCppScope_t GetScopeFromCompleteName(TCppSema_t sema,
-                                       const std::string &name);
+  TCppScope_t GetScopeFromCompleteName(const std::string &name);
 
-  TCppScope_t GetNamed(TCppSema_t sema, const std::string &name,
+  TCppScope_t GetNamed(const std::string &name,
                        TCppScope_t parent = nullptr);
 
   TCppScope_t GetParentScope(TCppScope_t scope);
@@ -193,26 +190,23 @@ namespace InterOp {
 
   TCppScope_t GetBaseClass(TCppType_t klass, TCppIndex_t ibase);
 
-  bool IsSubclass(TInterp_t interp, TCppScope_t derived, TCppScope_t base);
+  bool IsSubclass(TCppScope_t derived, TCppScope_t base);
 
-  int64_t GetBaseClassOffset(TCppSema_t sema, TCppScope_t derived,
-                             TCppScope_t base);
+  int64_t GetBaseClassOffset(TCppScope_t derived, TCppScope_t base);
 
-  std::vector<TCppFunction_t> GetClassMethods(TCppSema_t sema,
-                                              TCppScope_t klass);
+  std::vector<TCppFunction_t> GetClassMethods(TCppScope_t klass);
 
   ///\returns if a class has a default constructor.
   bool HasDefaultConstructor(TCppScope_t scope);
 
   ///\returns the default constructor of a class if any.
-  TCppFunction_t GetDefaultConstructor(TCppSema_t sema, TCppScope_t scope);
+  TCppFunction_t GetDefaultConstructor(TCppScope_t scope);
 
   ///\returns the class destructor.
-  TCppFunction_t GetDestructor(TCppSema_t sema, TCppScope_t scope);
+  TCppFunction_t GetDestructor(TCppScope_t scope);
 
-  std::vector<TCppFunction_t> GetFunctionsUsingName(TCppSema_t sema,
-                                                    TCppScope_t scope,
-                                                    const std::string &name);
+  std::vector<TCppFunction_t> GetFunctionsUsingName(
+        TCppScope_t scope, const std::string& name);
 
   TCppType_t GetFunctionReturnType(TCppFunction_t func);
 
@@ -231,8 +225,8 @@ namespace InterOp {
 
   bool IsTemplatedFunction(TCppFunction_t func);
 
-  bool ExistsFunctionTemplate(TCppSema_t sema, const std::string &name,
-                              TCppScope_t parent = 0);
+  bool ExistsFunctionTemplate(const std::string& name,
+          TCppScope_t parent = 0);
 
   bool IsMethod(TCppConstFunction_t method);
 
@@ -248,18 +242,17 @@ namespace InterOp {
 
   bool IsStaticMethod(TCppFunction_t method);
 
-  TCppFuncAddr_t GetFunctionAddress(TInterp_t interp, TCppFunction_t method);
+  TCppFuncAddr_t GetFunctionAddress(TCppFunction_t method);
 
   bool IsVirtualMethod(TCppFunction_t method);
 
   std::vector<TCppScope_t> GetDatamembers(TCppScope_t scope);
 
-  TCppScope_t LookupDatamember(TCppSema_t sema, const std::string &name,
-                               TCppScope_t parent);
+  TCppScope_t LookupDatamember(const std::string& name, TCppScope_t parent);
 
   TCppType_t GetVariableType(TCppScope_t var);
 
-  intptr_t GetVariableOffset(TInterp_t interp, TCppScope_t var);
+  intptr_t GetVariableOffset(TCppScope_t var);
 
   bool IsPublicVariable(TCppScope_t var);
 
@@ -273,7 +266,7 @@ namespace InterOp {
 
   bool IsRecordType(TCppType_t type);
 
-  bool IsPODType(TCppSema_t sema, TCppType_t type);
+  bool IsPODType(TCppType_t type);
 
   TCppType_t  GetUnderlyingType(TCppType_t type);
 
@@ -281,18 +274,18 @@ namespace InterOp {
 
   TCppType_t GetCanonicalType(TCppType_t type);
 
-  TCppType_t GetType(TCppSema_t sema, const std::string &type);
+  TCppType_t GetType(const std::string &type);
 
-  TCppType_t GetComplexType(TCppSema_t sema, TCppType_t element_type);
+  TCppType_t GetComplexType(TCppType_t element_type);
 
   TCppType_t GetTypeFromScope(TCppScope_t klass);
 
   /// Check if a C++ type derives from another.
-  bool IsTypeDerivedFrom(TInterp_t interp, TCppType_t derived, TCppType_t base);
+  bool IsTypeDerivedFrom(TCppType_t derived, TCppType_t base);
 
   /// Creates a trampoline function by using the interpreter and returns a
   /// uniform interface to call it from compiled code.
-  JitCall MakeFunctionCallable(TInterp_t interp, TCppConstFunction_t func);
+  JitCall MakeFunctionCallable(TCppConstFunction_t func);
 
   /// Checks if a function declared is of const type or not
   bool IsConstMethod(TCppFunction_t method);
@@ -310,32 +303,31 @@ namespace InterOp {
   ///           adds additional arguments to the interpreter.
   TInterp_t CreateInterpreter(const std::vector<const char*> &Args = {});
 
-  TCppSema_t GetSema(TInterp_t interp);
+  ///\returns the current interpreter instance, if any.
+  TInterp_t GetInterpreter();
 
-  void AddSearchPath(TInterp_t interp, const char *dir, bool isUser = true,
-                     bool prepend = false);
+  void AddSearchPath(const char *dir, bool isUser = true, bool prepend = false);
 
   /// Returns the resource-dir path.
-  const char *GetResourceDir(TInterp_t interp);
+  const char* GetResourceDir();
 
-  void AddIncludePath(TInterp_t interp, const char *dir);
+  void AddIncludePath(const char *dir);
 
-  TCppIndex_t Declare(TInterp_t interp, const char *code, bool silent = false);
+  TCppIndex_t Declare(const char *code, bool silent = false);
 
   /// Declares and runs a code snippet in \c code.
   ///\returns 0 on success
-  int Process(TInterp_t interp, const char *code);
+  int Process(const char *code);
 
   /// Declares, runs and returns the execution result as a intptr_t.
   ///\returns the expression results as a intptr_t.
-  intptr_t Evaluate(TInterp_t interp, const char *code,
-                    bool *HadError = nullptr);
+  intptr_t Evaluate(const char *code, bool *HadError = nullptr);
 
-  const std::string LookupLibrary(TInterp_t interp, const char *lib_name);
+  const std::string LookupLibrary(const char *lib_name);
 
-  bool LoadLibrary(TInterp_t interp, const char *lib_path, bool lookup = true);
+  bool LoadLibrary(const char *lib_path, bool lookup = true);
 
-  std::string ObjToString(TInterp_t interp, const char *type, void *obj);
+  std::string ObjToString(const char *type, void *obj);
 
   struct TemplateArgInfo {
     TCppScope_t m_Type;
@@ -343,8 +335,8 @@ namespace InterOp {
     TemplateArgInfo(TCppScope_t type, const char* integral_value = nullptr)
       : m_Type(type), m_IntegralValue(integral_value) {}
   };
-  TCppScope_t InstantiateClassTemplate(TInterp_t interp, TCppScope_t tmpl,
-                                       TemplateArgInfo *template_args,
+  TCppScope_t InstantiateClassTemplate(TCppScope_t tmpl,
+                                       TemplateArgInfo* template_args,
                                        size_t template_args_size);
 
   std::vector<std::string> GetAllCppNames(TCppScope_t scope);
@@ -367,12 +359,12 @@ namespace InterOp {
 
   /// Creates an object of class \c scope and calls its default constructor. If
   /// \c arena is set it uses placement new.
-  TCppObject_t Construct(TInterp_t interp, TCppScope_t scope,
-                         void *arena = nullptr);
+  TCppObject_t Construct(TCppScope_t scope,
+                         void* arena = nullptr);
 
   /// Calls the destructor of object of type \c type. When withFree is true it
   /// calls operator delete/free.
-  void Destruct(TInterp_t interp, TCppObject_t This, TCppScope_t type,
+  void Destruct(TCppObject_t This, TCppScope_t type,
                 bool withFree = true);
 } // end namespace InterOp
 

--- a/lib/Interpreter/InterOp.cpp
+++ b/lib/Interpreter/InterOp.cpp
@@ -39,6 +39,23 @@ namespace InterOp {
   using namespace llvm;
   using namespace std;
 
+  static std::unique_ptr<compat::Interpreter> sInterpreter;
+  // Valgrind complains about __cxa_pure_virtual called when deleting
+  // llvm::SectionMemoryManager::~SectionMemoryManager as part of the dtor chain
+  // of the Interpreter.
+  // This might fix the issue https://reviews.llvm.org/D107087
+  // FIXME: For now we just leak the Interpreter.
+  struct InterpDeleter {
+    ~InterpDeleter() { sInterpreter.release(); }
+  } Deleter;
+
+  static compat::Interpreter& getInterp() {
+    assert(sInterpreter.get() && "Must be set before calling this!");
+    return *sInterpreter.get();
+  }
+  static clang::Sema& getSema() { return getInterp().getCI()->getSema(); }
+  static clang::ASTContext& getASTContext() { return getSema().getASTContext(); }
+
 #define DEBUG_TYPE "jitcall"
   bool JitCall::AreArgumentsValid(void* result, ArgList args,
                                   void* self) const {
@@ -130,11 +147,29 @@ namespace InterOp {
     Decl *D = static_cast<Decl*>(scope);
     return isa<CXXRecordDecl>(D);
   }
+
+  static SourceLocation GetValidSLoc(Sema& semaRef) {
+    auto& SM = semaRef.getSourceManager();
+    return SM.getLocForStartOfFile(SM.getMainFileID());
+  }
+
   // See TClingClassInfo::IsLoaded
   bool IsComplete(TCppScope_t scope) {
     if (!scope)
       return false;
+
     Decl *D = static_cast<Decl*>(scope);
+
+    if (isa<ClassTemplateSpecializationDecl>(D)) {
+      QualType QT = QualType::getFromOpaquePtr(GetTypeFromScope(scope));
+      clang::Sema &S = getSema();
+      SourceLocation fakeLoc = GetValidSLoc(S);
+#ifdef USE_CLING
+      cling::Interpreter::PushTransactionRAII RAII(&getInterp());
+#endif // USE_CLING
+      return S.isCompleteType(fakeLoc, QT);
+    }
+
     if (auto *CXXRD = dyn_cast<CXXRecordDecl>(D))
       return CXXRD->hasDefinition();
     else if (auto *TD = dyn_cast<TagDecl>(D))
@@ -312,14 +347,13 @@ namespace InterOp {
     return 0;
   }
 
-  size_t GetSizeOfType(TCppSema_t sema, TCppType_t type) {
-    auto S = (clang::Sema *)sema;
+  size_t GetSizeOfType(TCppType_t type) {
     QualType QT = QualType::getFromOpaquePtr(type);
     if (const TagType *TT = QT->getAs<TagType>())
       return SizeOf(TT->getDecl());
 
     // FIXME: Can we get the size of a non-tag type?
-    auto TI = S->getASTContext().getTypeInfo(QT);
+    auto TI = getSema().getASTContext().getTypeInfo(QT);
     size_t TypeSize = TI.Width;
     return TypeSize/8;
   }
@@ -343,9 +377,9 @@ namespace InterOp {
     return "<unnamed>";
   }
 
-  std::string GetCompleteName(TCppSema_t sema, TCppType_t klass) {
-    auto S = (clang::Sema *)sema;
-    auto &C = S->getASTContext();
+  std::string GetCompleteName(TCppType_t klass)
+  {
+    auto &C = getSema().getASTContext();
     auto *D = (Decl *) klass;
 
     if (auto *ND = llvm::dyn_cast_or_null<NamedDecl>(D)) {
@@ -384,9 +418,10 @@ namespace InterOp {
     return "<unnamed>";
   }
 
-  std::string GetQualifiedCompleteName(TCppSema_t sema, TCppType_t klass) {
-    auto S = (clang::Sema *)sema;
-    auto &C = S->getASTContext();
+  //FIXME: Figure out how to merge with GetCompleteName.
+  std::string GetQualifiedCompleteName(TCppType_t klass)
+  {
+    auto &C = getSema().getASTContext();
     auto *D = (Decl *) klass;
 
     if (auto *ND = llvm::dyn_cast_or_null<NamedDecl>(D)) {
@@ -422,17 +457,17 @@ namespace InterOp {
     return {};
   }
 
-  TCppScope_t GetGlobalScope(TCppSema_t sema) {
-    auto *S = (Sema *)sema;
-    return S->getASTContext().getTranslationUnitDecl();
+  TCppScope_t GetGlobalScope()
+  {
+    return getSema().getASTContext().getTranslationUnitDecl();
   }
 
-  TCppScope_t GetScope(TCppSema_t sema, const std::string &name,
-                       TCppScope_t parent) {
+  TCppScope_t GetScope(const std::string &name, TCppScope_t parent)
+  {
     if (name == "")
-      return GetGlobalScope(sema);
+        return GetGlobalScope();
 
-    auto *ND = (NamedDecl *)GetNamed(sema, name, parent);
+    auto *ND = (NamedDecl*)GetNamed(name, parent);
 
     if (!(ND == (NamedDecl *) -1) &&
             (llvm::isa_and_nonnull<NamespaceDecl>(ND)     ||
@@ -444,32 +479,31 @@ namespace InterOp {
     return 0;
   }
 
-  TCppScope_t GetScopeFromCompleteName(TCppSema_t sema,
-                                       const std::string &name) {
+  TCppScope_t GetScopeFromCompleteName(const std::string &name)
+  {
     std::string delim = "::";
     size_t start = 0;
     size_t end = name.find(delim);
     TCppScope_t curr_scope = 0;
-    auto *S = (Sema *)sema;
     while (end != std::string::npos)
     {
-      curr_scope = GetScope(S, name.substr(start, end - start), curr_scope);
+      curr_scope = GetScope(name.substr(start, end - start), curr_scope);
       start = end + delim.length();
       end = name.find(delim, start);
     }
-    return GetScope(S, name.substr(start, end), curr_scope);
+    return GetScope(name.substr(start, end), curr_scope);
   }
 
-  TCppScope_t GetNamed(TCppSema_t sema, const std::string &name,
-                       TCppScope_t parent /*= nullptr*/) {
+  TCppScope_t GetNamed(const std::string &name,
+                       TCppScope_t parent /*= nullptr*/)
+  {
     clang::DeclContext *Within = 0;
     if (parent) {
       auto *D = (clang::Decl *)parent;
       Within = llvm::dyn_cast<clang::DeclContext>(D);
     }
 
-    auto *S = (Sema *)sema;
-    auto *ND = InterOp_utils::Lookup::Named(S, name, Within);
+    auto *ND = InterOp_utils::Lookup::Named(&getSema(), name, Within);
     if (ND && ND != (clang::NamedDecl*) -1) {
       return (TCppScope_t)(ND->getCanonicalDecl());
     }
@@ -542,7 +576,8 @@ namespace InterOp {
 
   // FIXME: Consider dropping this interface as it seems the same as
   // IsTypeDerivedFrom.
-  bool IsSubclass(TInterp_t interp, TCppScope_t derived, TCppScope_t base) {
+  bool IsSubclass(TCppScope_t derived, TCppScope_t base)
+  {
     if (derived == base)
       return true;
 
@@ -557,7 +592,7 @@ namespace InterOp {
 
     auto Derived = cast<CXXRecordDecl>(derived_D);
     auto Base = cast<CXXRecordDecl>(base_D);
-    return IsTypeDerivedFrom(interp, GetTypeFromScope(Derived),
+    return IsTypeDerivedFrom(GetTypeFromScope(Derived),
                              GetTypeFromScope(Base));
   }
 
@@ -607,8 +642,7 @@ namespace InterOp {
 
   }
 
-  int64_t GetBaseClassOffset(TCppSema_t sema, TCppScope_t derived,
-                             TCppScope_t base) {
+  int64_t GetBaseClassOffset(TCppScope_t derived, TCppScope_t base) {
     if (base == derived)
       return 0;
 
@@ -616,7 +650,6 @@ namespace InterOp {
 
     auto *DD = (Decl *) derived;
     auto *BD = (Decl *) base;
-    auto *S = (Sema *)sema;
     if (!isa<CXXRecordDecl>(DD) || !isa<CXXRecordDecl>(BD))
       return -1;
     CXXRecordDecl *DCXXRD = cast<CXXRecordDecl>(DD);
@@ -626,26 +659,25 @@ namespace InterOp {
     DCXXRD->isDerivedFrom(BCXXRD, Paths);
 
     // FIXME: We might want to cache these requests as they seem expensive.
-    return ComputeBaseOffset(S->getASTContext(), DCXXRD, Paths.front());
+    return ComputeBaseOffset(getSema().getASTContext(), DCXXRD, Paths.front());
   }
 
   // FIXME: We should make the std::vector<TCppFunction_t> an out parameter to
   // avoid copies.
-  std::vector<TCppFunction_t> GetClassMethods(TCppSema_t sema,
-                                              TCppScope_t klass) {
+  std::vector<TCppFunction_t> GetClassMethods(TCppScope_t klass)
+  {
 
     if (!klass)
       return {};
 
     auto *D = (clang::Decl *) klass;
-    auto *S = (Sema *)sema;
 
     if (auto *TD = dyn_cast<TypedefNameDecl>(D))
       D = GetScopeFromType(TD->getUnderlyingType());
 
     std::vector<TCppFunction_t> methods;
     if (auto *CXXRD = dyn_cast_or_null<CXXRecordDecl>(D)) {
-      S->ForceDeclarationOfImplicitMembers(CXXRD);
+      getSema().ForceDeclarationOfImplicitMembers(CXXRD);
       for (Decl* DI : CXXRD->decls()) {
         if (auto* MD = dyn_cast<CXXMethodDecl>(DI))
           methods.push_back(MD);
@@ -667,22 +699,19 @@ namespace InterOp {
     return false;
   }
 
-  TCppFunction_t GetDefaultConstructor(TCppSema_t sema, TCppScope_t scope) {
+  TCppFunction_t GetDefaultConstructor(TCppScope_t scope) {
     if (!HasDefaultConstructor(scope))
       return nullptr;
 
-    clang::Sema *S = (clang::Sema *)sema;
-
     auto *CXXRD = (clang::CXXRecordDecl*)scope;
-    return S->LookupDefaultConstructor(CXXRD);
+    return getSema().LookupDefaultConstructor(CXXRD);
   }
 
-  TCppFunction_t GetDestructor(TCppSema_t sema, TCppScope_t scope) {
+  TCppFunction_t GetDestructor(TCppScope_t scope) {
     auto *D = (clang::Decl *) scope;
 
     if (auto *CXXRD = llvm::dyn_cast_or_null<CXXRecordDecl>(D)) {
-      clang::Sema *S = (clang::Sema *)sema;
-      S->ForceDeclarationOfImplicitMembers(CXXRD);
+      getSema().ForceDeclarationOfImplicitMembers(CXXRD);
       return CXXRD->getDestructor();
     }
 
@@ -695,9 +724,9 @@ namespace InterOp {
     D->dump();
   }
 
-  std::vector<TCppFunction_t> GetFunctionsUsingName(TCppSema_t sema,
-                                                    TCppScope_t scope,
-                                                    const std::string &name) {
+  std::vector<TCppFunction_t> GetFunctionsUsingName(
+        TCppScope_t scope, const std::string& name)
+  {
     auto *D = (Decl *) scope;
 
     if (!scope || name.empty())
@@ -708,24 +737,24 @@ namespace InterOp {
 
     std::vector<TCppFunction_t> funcs;
     llvm::StringRef Name(name);
-    auto *S = (Sema *)sema;
-    DeclarationName DName = &S->Context.Idents.get(name);
-    clang::LookupResult R(*S, DName, SourceLocation(), Sema::LookupOrdinaryName,
+    auto &S = getSema();
+    DeclarationName DName = &getASTContext().Idents.get(name);
+    clang::LookupResult R(S,
+                          DName,
+                          SourceLocation(),
+                          Sema::LookupOrdinaryName,
                           Sema::ForVisibleRedeclaration);
 
-    InterOp_utils::Lookup::Named(S, R, Decl::castToDeclContext(D));
+    InterOp_utils::Lookup::Named(&S, R, Decl::castToDeclContext(D));
 
     if (R.empty())
       return funcs;
 
     R.resolveKind();
 
-    for (clang::LookupResult::iterator Res = R.begin(), ResEnd = R.end();
-         Res != ResEnd; ++Res) {
-      if (llvm::isa<FunctionDecl>(*Res)) {
-        funcs.push_back((TCppFunction_t)*Res);
-      }
-    }
+    for (auto *Found : R)
+      if (llvm::isa<FunctionDecl>(Found))
+        funcs.push_back(Found);
 
     return funcs;
   }
@@ -781,7 +810,7 @@ namespace InterOp {
     if (auto *FD = llvm::dyn_cast<FunctionDecl>(D)) {
       std::string Signature;
       raw_string_ostream SS(Signature);
-      PrintingPolicy Policy = FD->getASTContext().getPrintingPolicy();
+      PrintingPolicy Policy = getASTContext().getPrintingPolicy();
       // Skip printing the body
       Policy.TerseOutput = true;
       Policy.FullyQualifiedName = true;
@@ -823,16 +852,16 @@ namespace InterOp {
     return IsTemplatedFunction(D);
   }
 
-  bool ExistsFunctionTemplate(TCppSema_t sema, const std::string &name,
-                              TCppScope_t parent) {
+  bool ExistsFunctionTemplate(const std::string& name,
+          TCppScope_t parent)
+  {
     DeclContext *Within = 0;
     if (parent) {
       auto *D = (Decl *)parent;
       Within = llvm::dyn_cast<DeclContext>(D);
     }
 
-    auto *S = (Sema *)sema;
-    auto *ND = InterOp_utils::Lookup::Named(S, name, Within);
+    auto *ND = InterOp_utils::Lookup::Named(&getSema(), name, Within);
 
     if ((intptr_t) ND == (intptr_t) 0)
       return false;
@@ -896,12 +925,12 @@ namespace InterOp {
     return false;
   }
 
-  TCppFuncAddr_t GetFunctionAddress(TInterp_t interp, TCppFunction_t method) {
-    auto *I = (compat::Interpreter *)interp;
+  TCppFuncAddr_t GetFunctionAddress(TCppFunction_t method)
+  {
     auto *D = (Decl *) method;
 
-    const auto get_mangled_name = [](FunctionDecl *FD) {
-      auto MangleCtxt = FD->getASTContext().createMangleContext();
+    const auto get_mangled_name = [](FunctionDecl* FD) {
+      auto MangleCtxt = getASTContext().createMangleContext();
 
       if (!MangleCtxt->shouldMangleDeclName(FD)) {
         return FD->getNameInfo().getName().getAsString();
@@ -918,9 +947,9 @@ namespace InterOp {
       return mangled_name;
     };
 
+    auto &I = getInterp();
     if (auto *FD = llvm::dyn_cast_or_null<FunctionDecl>(D)) {
-      auto FDAorErr =
-          compat::getSymbolAddress(*I, StringRef(get_mangled_name(FD)));
+      auto FDAorErr = compat::getSymbolAddress(I, StringRef(get_mangled_name(FD)));
       if (llvm::Error Err = FDAorErr.takeError())
         llvm::logAllUnhandledErrors(std::move(Err), llvm::errs(), "Failed to GetFunctionAdress:");
       else
@@ -956,16 +985,16 @@ namespace InterOp {
     return {};
   }
 
-  TCppScope_t LookupDatamember(TCppSema_t sema, const std::string &name,
-                               TCppScope_t parent) {
+  TCppScope_t LookupDatamember(                               const std::string& name,
+                               TCppScope_t parent)
+  {
     clang::DeclContext *Within = 0;
     if (parent) {
       auto *D = (clang::Decl *)parent;
       Within = llvm::dyn_cast<clang::DeclContext>(D);
     }
 
-    auto *S = (Sema *)sema;
-    auto *ND = InterOp_utils::Lookup::Named(S, name, Within);
+    auto *ND = InterOp_utils::Lookup::Named(&getSema(), name, Within);
     if (ND && ND != (clang::NamedDecl*) -1) {
       if (llvm::isa_and_nonnull<clang::FieldDecl>(ND)) {
         return (TCppScope_t)ND;
@@ -986,14 +1015,13 @@ namespace InterOp {
     return 0;
   }
 
-  intptr_t GetVariableOffset(TInterp_t interp, TCppScope_t var) {
+  intptr_t GetVariableOffset(TCppScope_t var)
+  {
     if (!var)
       return 0;
 
     auto *D = (Decl *) var;
-    auto *I = (compat::Interpreter *)interp;
-    auto *S = &I->getSema();
-    auto &C = S->getASTContext();
+    auto &C = getASTContext();
 
     if (auto *FD = llvm::dyn_cast<FieldDecl>(D))
       return (intptr_t) C.toCharUnitsFromBits(C.getASTRecordLayout(FD->getParent())
@@ -1004,8 +1032,9 @@ namespace InterOp {
       std::string mangledName;
       compat::maybeMangleDeclName(GD, mangledName);
       auto address = dlsym(/*whole_process=*/0, mangledName.c_str());
+      auto &I = getInterp();
       if (!address)
-        address = I->getAddressOfGlobal(GD);
+        address = I.getAddressOfGlobal(GD);
       if (!address) {
         auto Linkage = C.GetGVALinkageForVariable(VD);
         // The decl was deferred by CodeGen. Force its emission.
@@ -1015,12 +1044,12 @@ namespace InterOp {
         if (isDiscardableGVALinkage(Linkage))
           VD->addAttr(UsedAttr::CreateImplicit(C));
 #ifdef USE_CLING
-        cling::Interpreter::PushTransactionRAII RAII(I);
-        I->getCI()->getASTConsumer().HandleTopLevelDecl(DeclGroupRef(VD));
+        cling::Interpreter::PushTransactionRAII RAII(&I);
+        I.getCI()->getASTConsumer().HandleTopLevelDecl(DeclGroupRef(VD));
 #else // CLANG_REPL
-        I->getCI()->getASTConsumer().HandleTopLevelDecl(DeclGroupRef(VD));
+        I.getCI()->getASTConsumer().HandleTopLevelDecl(DeclGroupRef(VD));
         // Take the newest llvm::Module produced by CodeGen and send it to JIT.
-        auto GeneratedPTU = I->Parse("");
+        auto GeneratedPTU = I.Parse("");
         if (!GeneratedPTU)
           llvm::logAllUnhandledErrors(GeneratedPTU.takeError(), llvm::errs(),
                                  "[GetVariableOffset] Failed to generate PTU:");
@@ -1035,12 +1064,12 @@ namespace InterOp {
             continue; //nothing to do
           GV.setLinkage(llvm::GlobalValue::WeakAnyLinkage);
         }
-        if (auto Err = I->Execute(*GeneratedPTU))
+        if (auto Err = I.Execute(*GeneratedPTU))
           llvm::logAllUnhandledErrors(std::move(Err), llvm::errs(),
                                   "[GetVariableOffset] Failed to execute PTU:");
 #endif
       }
-      auto VDAorErr = compat::getSymbolAddress(*I, StringRef(mangledName));
+      auto VDAorErr = compat::getSymbolAddress(I, StringRef(mangledName));
       if (!VDAorErr) {
         llvm::logAllUnhandledErrors(VDAorErr.takeError(), llvm::errs(),
                                     "Failed to GetVariableOffset:");
@@ -1104,16 +1133,14 @@ namespace InterOp {
     return QT->isRecordType();
   }
 
-  bool IsPODType(TCppSema_t sema, TCppType_t type) {
+  bool IsPODType(TCppType_t type)
+  {
     QualType QT = QualType::getFromOpaquePtr(type);
 
     if (QT.isNull())
       return false;
 
-    auto *S = (Sema *)sema;
-    auto &Cxt = S->getASTContext();
-
-    return QT.isPODType(Cxt);
+    return QT.isPODType(getASTContext());
   }
 
   TCppType_t GetUnderlyingType(TCppType_t type)
@@ -1197,14 +1224,12 @@ namespace InterOp {
     }
   }
 
-  TCppType_t GetType(TCppSema_t sema, const std::string &name) {
-    auto *S = (Sema *)sema;
-
-    QualType builtin = findBuiltinType(name, S->getASTContext());
+  TCppType_t GetType(const std::string &name) {
+    QualType builtin = findBuiltinType(name, getASTContext());
     if (!builtin.isNull())
       return builtin.getAsOpaquePtr();
 
-    auto *D = (Decl *)GetNamed(S, name, /* Within= */ 0);
+    auto *D = (Decl *) GetNamed(name, /* Within= */ 0);
     if (auto *TD = llvm::dyn_cast_or_null<TypeDecl>(D)) {
       return QualType(TD->getTypeForDecl(), 0).getAsOpaquePtr();
     }
@@ -1212,12 +1237,10 @@ namespace InterOp {
     return (TCppType_t) 0;
   }
 
-  TCppType_t GetComplexType(TCppSema_t sema, TCppType_t type) {
-    auto *S = (Sema *)sema;
+  TCppType_t GetComplexType(TCppType_t type) {
     QualType QT = QualType::getFromOpaquePtr(type);
-    auto &Cxt = S->getASTContext();
 
-    return Cxt.getComplexType(QT).getAsOpaquePtr();
+    return getASTContext().getComplexType(QT).getAsOpaquePtr();
   }
 
   TCppType_t GetTypeFromScope(TCppScope_t klass) {
@@ -1225,7 +1248,10 @@ namespace InterOp {
       return 0;
 
     auto *D = (Decl *) klass;
-    ASTContext &C = D->getASTContext();
+    ASTContext &C = getASTContext();
+
+    if (ValueDecl *VD = dyn_cast<ValueDecl>(D))
+      return VD->getType().getAsOpaquePtr();
 
     return C.getTypeDeclType(cast<TypeDecl>(D)).getAsOpaquePtr();
   }
@@ -1245,12 +1271,12 @@ namespace InterOp {
         buf << kIndentString;
     }
 
-    void *compile_wrapper(compat::Interpreter *I,
-                          const std::string &wrapper_name,
-                          const std::string &wrapper,
+    void *compile_wrapper(compat::Interpreter& I,
+                          const std::string& wrapper_name,
+                          const std::string& wrapper,
                           bool withAccessControl = true) {
       LLVM_DEBUG(dbgs() << "Compiling '" << wrapper_name << "'\n");
-      return I->compileFunction(wrapper_name, wrapper, false /*ifUnique*/,
+      return I.compileFunction(wrapper_name, wrapper, false /*ifUnique*/,
                                 withAccessControl);
     }
 
@@ -1586,10 +1612,10 @@ namespace InterOp {
       buf << "}\n";
     }
 
-    void make_narg_call_with_return(compat::Interpreter *I,
-                                    const FunctionDecl *FD, const unsigned N,
-                                    const std::string &class_name,
-                                    std::ostringstream &buf, int indent_level) {
+    void make_narg_call_with_return(compat::Interpreter& I,
+                                    const FunctionDecl* FD, const unsigned N,
+                                    const std::string& class_name,
+                                    std::ostringstream& buf, int indent_level) {
       // Make a code string that follows this pattern:
       //
       // if (ret) {
@@ -1601,7 +1627,7 @@ namespace InterOp {
       //
       if (const CXXConstructorDecl* CD = dyn_cast<CXXConstructorDecl>(FD)) {
         if (N <= 1 && llvm::isa<UsingShadowDecl>(FD)) {
-          auto SpecMemKind = I->getCI()->getSema().getSpecialMember(CD);
+          auto SpecMemKind = I.getCI()->getSema().getSpecialMember(CD);
           if ((N == 0 && SpecMemKind == clang::Sema::CXXDefaultConstructor) ||
               (N == 1 && (SpecMemKind == clang::Sema::CXXCopyConstructor ||
                           SpecMemKind == clang::Sema::CXXMoveConstructor))) {
@@ -1718,8 +1744,8 @@ namespace InterOp {
       }
     }
 
-    int get_wrapper_code(compat::Interpreter *I, const FunctionDecl *FD,
-                         std::string &wrapper_name, std::string &wrapper) {
+    int get_wrapper_code(compat::Interpreter& I, const FunctionDecl* FD,
+                         std::string& wrapper_name, std::string& wrapper) {
       assert(FD && "generate_wrapper called without a function decl!");
       ASTContext& Context = FD->getASTContext();
       PrintingPolicy Policy(Context.getPrintingPolicy());
@@ -1958,10 +1984,10 @@ namespace InterOp {
       }
       if (needInstantiation) {
         clang::FunctionDecl* FDmod = const_cast<clang::FunctionDecl*>(FD);
-        clang::Sema &S = I->getCI()->getSema();
+        clang::Sema& S = I.getCI()->getSema();
         // Could trigger deserialization of decls.
 #ifdef USE_CLING
-        cling::Interpreter::PushTransactionRAII RAII(I);
+        cling::Interpreter::PushTransactionRAII RAII(&I);
 #endif
         S.InstantiateFunctionDefinition(SourceLocation(), FDmod,
                                         /*Recursive=*/true,
@@ -2152,8 +2178,8 @@ namespace InterOp {
       return 1;
     }
 
-    JitCall::GenericCall make_wrapper(compat::Interpreter *I,
-                                      const FunctionDecl *FD) {
+    JitCall::GenericCall make_wrapper(compat::Interpreter& I,
+                                      const FunctionDecl* FD) {
       static std::map<const FunctionDecl*, void *> gWrapperStore;
 
       auto R = gWrapperStore.find(FD);
@@ -2235,8 +2261,8 @@ namespace InterOp {
       return wrapper_name;
     }
 
-    static JitCall::DestructorCall
-    make_dtor_wrapper(compat::Interpreter *interp, const Decl *D) {
+    static JitCall::DestructorCall make_dtor_wrapper(compat::Interpreter& interp,
+                                                              const Decl *D) {
       // Make a code string that follows this pattern:
       //
       // void
@@ -2384,12 +2410,12 @@ namespace InterOp {
 #undef DEBUG_TYPE
   } // namespace
 
-  JitCall MakeFunctionCallable(TInterp_t interp, TCppConstFunction_t func) {
-    auto *I = (compat::Interpreter *)interp;
+  JitCall MakeFunctionCallable(TCppConstFunction_t func) {
     auto* D = (const clang::Decl*)func;
     if (!D)
       return {};
 
+    auto& I = getInterp();
     // FIXME: Unify with make_wrapper.
     if (auto *Dtor = dyn_cast<CXXDestructorDecl>(D)) {
       if (auto Wrapper = make_dtor_wrapper(I, Dtor->getParent()))
@@ -2469,32 +2495,28 @@ namespace InterOp {
       Args[NumArgs + 1] = nullptr;
       llvm::cl::ParseCommandLineOptions(NumArgs + 1, Args.get());
     }
+    // FIXME: Enable this assert once we figure out how to fix the multiple
+    // calls to CreateInterpreter.
+    //assert(!sInterpreter && "Interpreter already set.");
+    sInterpreter.reset(I);
     return I;
   }
 
-  TCppSema_t GetSema(TInterp_t interp) {
-    auto *I = (compat::Interpreter *)interp;
-
-    return (TCppSema_t)&I->getSema();
+  TInterp_t GetInterpreter() {
+    return sInterpreter.get();
   }
 
-  void AddSearchPath(TInterp_t interp, const char *dir, bool isUser,
+  void AddSearchPath(const char *dir, bool isUser,
                      bool prepend) {
-    auto *I = (compat::Interpreter *)interp;
-
-    I->getDynamicLibraryManager()->addSearchPath(dir, isUser, prepend);
+    getInterp().getDynamicLibraryManager()->addSearchPath(dir, isUser, prepend);
   }
 
-  const char *GetResourceDir(TInterp_t interp) {
-    auto *I = (compat::Interpreter *)interp;
-
-    return I->getCI()->getHeaderSearchOpts().ResourceDir.c_str();
+  const char* GetResourceDir() {
+    return getInterp().getCI()->getHeaderSearchOpts().ResourceDir.c_str();
   }
 
-  void AddIncludePath(TInterp_t interp, const char *dir) {
-    auto *I = (compat::Interpreter *)interp;
-
-    I->AddIncludePath(dir);
+  void AddIncludePath(const char *dir) {
+    getInterp().AddIncludePath(dir);
   }
 
   namespace {
@@ -2514,27 +2536,23 @@ namespace InterOp {
   };
   } // namespace
 
-  TCppIndex_t Declare(TInterp_t interp, const char *code, bool silent) {
-    auto *I = (compat::Interpreter *)interp;
+  TCppIndex_t Declare(const char *code, bool silent) {
+    auto& I = getInterp();
 
     if (silent) {
-      clangSilent diagSuppr(I->getSema().getDiagnostics());
-      return I->declare(code);
+      clangSilent diagSuppr(I.getSema().getDiagnostics());
+      return I.declare(code);
     }
 
-    return I->declare(code);
+    return I.declare(code);
   }
 
-  int Process(TInterp_t interp, const char *code) {
-    auto *I = (compat::Interpreter *)interp;
-
-    return I->process(code);
+  int Process(const char *code) {
+    return getInterp().process(code);
   }
 
-  intptr_t Evaluate(TInterp_t interp, const char *code,
-                    bool *HadError /*=nullptr*/) {
-    auto *I = (compat::Interpreter *)interp;
-
+  intptr_t Evaluate(const char *code,
+                    bool *HadError/*=nullptr*/) {
 #ifdef USE_CLING
     cling::Value V;
 #else
@@ -2543,7 +2561,8 @@ namespace InterOp {
 
     if (HadError)
       *HadError = false;
-    auto res = I->evaluate(code, V);
+
+    auto res = getInterp().evaluate(code, V);
     if (res != 0) { // 0 is success
       if (HadError)
         *HadError = true;
@@ -2554,28 +2573,19 @@ namespace InterOp {
     return V.castAs<intptr_t>();
   }
 
-  const std::string LookupLibrary(TInterp_t interp, const char *lib_name) {
-    auto *I = (compat::Interpreter *)interp;
-
-    return I->getDynamicLibraryManager()->lookupLibrary(lib_name);
+  const std::string LookupLibrary(const char *lib_name) {
+    return getInterp().getDynamicLibraryManager()->lookupLibrary(lib_name);
   }
 
-  bool LoadLibrary(TInterp_t interp, const char *lib_name, bool lookup) {
-    auto *I = (compat::Interpreter *)interp;
+  bool LoadLibrary(const char *lib_name, bool lookup) {
     compat::Interpreter::CompilationResult res =
-        I->loadLibrary(lib_name, lookup);
+      getInterp().loadLibrary(lib_name, lookup);
 
     return res == compat::Interpreter::kSuccess;
   }
 
-  std::string ObjToString(TInterp_t interp, const char *type, void *obj) {
-    auto *I = (compat::Interpreter *)interp;
-    return I->toString(type, obj);
-  }
-
-  static SourceLocation GetValidSLoc(Sema &semaRef) {
-    auto &SM = semaRef.getSourceManager();
-    return SM.getLocForStartOfFile(SM.getMainFileID());
+  std::string ObjToString(const char *type, void *obj) {
+    return getInterp().toString(type, obj);
   }
 
   static QualType InstantiateTemplate(TemplateDecl* ClassDecl,
@@ -2614,11 +2624,10 @@ namespace InterOp {
     return InstantiateTemplate(ClassDecl, TLI, S);
   }
 
-  TCppScope_t InstantiateClassTemplate(TInterp_t interp, TCppScope_t tmpl,
-                                       TemplateArgInfo *template_args,
+  TCppScope_t InstantiateClassTemplate(TCppScope_t tmpl,
+                                       TemplateArgInfo* template_args,
                                        size_t template_args_size) {
-    auto *I = (compat::Interpreter *)interp;
-    ASTContext &C = I->getSema().getASTContext();
+    ASTContext &C = getASTContext();
 
     llvm::SmallVector<TemplateArgument> TemplateArgs;
     TemplateArgs.reserve(template_args_size);
@@ -2639,9 +2648,9 @@ namespace InterOp {
 
     // We will create a new decl, push a transaction.
 #ifdef USE_CLING
-    cling::Interpreter::PushTransactionRAII RAII(I);
+    cling::Interpreter::PushTransactionRAII RAII(&getInterp());
 #endif
-    QualType Instance = InstantiateTemplate(TmplD, TemplateArgs, I->getSema());
+    QualType Instance = InstantiateTemplate(TmplD, TemplateArgs, getSema());
     return GetScopeFromType(Instance);
   }
 
@@ -2728,18 +2737,17 @@ namespace InterOp {
     return dims;
   }
 
-  bool IsTypeDerivedFrom(TInterp_t interp, TCppType_t derived,
-                         TCppType_t base) {
-    auto *I = (compat::Interpreter *)interp;
-    auto *S = &I->getSema();
-    auto fakeLoc = GetValidSLoc(*S);
+  bool IsTypeDerivedFrom(TCppType_t derived, TCppType_t base)
+  {
+    auto &S = getSema();
+    auto fakeLoc = GetValidSLoc(S);
     auto derivedType = clang::QualType::getFromOpaquePtr(derived);
     auto baseType = clang::QualType::getFromOpaquePtr(base);
 
 #ifdef USE_CLING
-    cling::Interpreter::PushTransactionRAII RAII(I);
+    cling::Interpreter::PushTransactionRAII RAII(&getInterp());
 #endif
-    return S->IsDerivedFrom(fakeLoc, derivedType, baseType);
+    return S.IsDerivedFrom(fakeLoc,derivedType,baseType);
   }
 
   std::string GetFunctionArgDefault(TCppFunction_t func, TCppIndex_t param_index)
@@ -2802,16 +2810,15 @@ namespace InterOp {
   }
 
   // FIXME: Add optional arguments to the operator new.
-  TCppObject_t Construct(TInterp_t interp, TCppScope_t scope,
-                         void *arena /*=nullptr*/) {
+  TCppObject_t Construct(TCppScope_t scope,
+                         void* arena/*=nullptr*/) {
     auto* Class = (Decl*) scope;
-    auto *I = (compat::Interpreter *)interp;
     // FIXME: Diagnose.
     if (!HasDefaultConstructor(Class))
       return nullptr;
 
-    auto *const Ctor = GetDefaultConstructor(GetSema(I), Class);
-    if (JitCall JC = MakeFunctionCallable(I, Ctor)) {
+    auto* const Ctor = GetDefaultConstructor(Class);
+    if (JitCall JC = MakeFunctionCallable(Ctor)) {
       if (arena) {
         JC.Invoke(arena);
         return arena;
@@ -2824,11 +2831,10 @@ namespace InterOp {
     return nullptr;
   }
 
-  void Destruct(TInterp_t interp, TCppObject_t This, TCppScope_t scope,
-                bool withFree /*=true*/) {
+  void Destruct(TCppObject_t This, TCppScope_t scope,
+                bool withFree/*=true*/) {
     Decl* Class = (Decl*)scope;
-    auto *I = (compat::Interpreter *)interp;
-    if (auto wrapper = make_dtor_wrapper(I, Class)) {
+    if (auto wrapper = make_dtor_wrapper(getInterp(), Class)) {
       (*wrapper)(This, /*nary=*/0, withFree);
       return;
     }

--- a/unittests/InterOp/InterpreterTest.cpp
+++ b/unittests/InterOp/InterpreterTest.cpp
@@ -3,50 +3,48 @@
 #include "gtest/gtest.h"
 
 TEST(InterpreterTest, DebugFlag) {
-  auto I = InterOp::CreateInterpreter();
   EXPECT_FALSE(InterOp::IsDebugOutputEnabled());
   std::string cerrs;
   testing::internal::CaptureStderr();
-  InterOp::Process(I, "int a = 12;");
+  InterOp::Process("int a = 12;");
   cerrs = testing::internal::GetCapturedStderr();
   EXPECT_STREQ(cerrs.c_str(), "");
   InterOp::EnableDebugOutput();
   EXPECT_TRUE(InterOp::IsDebugOutputEnabled());
   testing::internal::CaptureStderr();
-  InterOp::Process(I, "int b = 12;");
+  InterOp::Process("int b = 12;");
   cerrs = testing::internal::GetCapturedStderr();
   EXPECT_STRNE(cerrs.c_str(), "");
 
   InterOp::EnableDebugOutput(false);
   EXPECT_FALSE(InterOp::IsDebugOutputEnabled());
   testing::internal::CaptureStderr();
-  InterOp::Process(I, "int c = 12;");
+  InterOp::Process("int c = 12;");
   cerrs = testing::internal::GetCapturedStderr();
   EXPECT_STREQ(cerrs.c_str(), "");
 }
 
 TEST(InterpreterTest, Evaluate) {
-  auto I = InterOp::CreateInterpreter();
   //  EXPECT_TRUE(InterOp::Evaluate(I, "") == 0);
   //EXPECT_TRUE(InterOp::Evaluate(I, "__cplusplus;") == 201402);
   // Due to a deficiency in the clang-repl implementation to get the value we
   // always must omit the ;
-  EXPECT_TRUE(InterOp::Evaluate(I, "__cplusplus") == 201402);
+  EXPECT_TRUE(InterOp::Evaluate("__cplusplus") == 201402);
 
   bool HadError;
-  EXPECT_TRUE(InterOp::Evaluate(I, "#error", &HadError) == (intptr_t)~0UL);
+  EXPECT_TRUE(InterOp::Evaluate("#error", &HadError) == (intptr_t)~0UL);
   EXPECT_TRUE(HadError);
-  EXPECT_EQ(InterOp::Evaluate(I, "int i = 11; ++i", &HadError), 12);
+  EXPECT_EQ(InterOp::Evaluate("int i = 11; ++i", &HadError), 12);
   EXPECT_FALSE(HadError) ;
 }
 
 TEST(InterpreterTest, Process) {
-  auto I = InterOp::CreateInterpreter();
-  EXPECT_TRUE(InterOp::Process(I, "") == 0);
-  EXPECT_TRUE(InterOp::Process(I, "int a = 12;") == 0);
-  EXPECT_FALSE(InterOp::Process(I, "error_here;") == 0);
+  InterOp::CreateInterpreter();
+  EXPECT_TRUE(InterOp::Process("") == 0);
+  EXPECT_TRUE(InterOp::Process("int a = 12;") == 0);
+  EXPECT_FALSE(InterOp::Process("error_here;") == 0);
   // Linker/JIT error.
-  EXPECT_FALSE(InterOp::Process(I, "int f(); int res = f();") == 0);
+  EXPECT_FALSE(InterOp::Process("int f(); int res = f();") == 0);
 }
 
 TEST(InterpreterTest, CreateInterpreter) {
@@ -54,20 +52,20 @@ TEST(InterpreterTest, CreateInterpreter) {
   EXPECT_TRUE(I);
   // Check if the default standard is c++14
 
-  InterOp::Declare(I, "#if __cplusplus==201402L\n"
-                      "int cpp14() { return 2014; }\n"
-                      "#else\n"
-                      "void cppUnknown() {}\n"
-                      "#endif");
-  EXPECT_TRUE(InterOp::GetNamed(InterOp::GetSema(I), "cpp14"));
-  EXPECT_FALSE(InterOp::GetNamed(InterOp::GetSema(I), "cppUnknown"));
+  InterOp::Declare("#if __cplusplus==201402L\n"
+                   "int cpp14() { return 2014; }\n"
+                   "#else\n"
+                   "void cppUnknown() {}\n"
+                   "#endif");
+  EXPECT_TRUE(InterOp::GetNamed("cpp14"));
+  EXPECT_FALSE(InterOp::GetNamed("cppUnknown"));
 
   I = InterOp::CreateInterpreter({"-std=c++17"});
-  InterOp::Declare(I, "#if __cplusplus==201703L\n"
-                      "int cpp17() { return 2017; }\n"
-                      "#else\n"
-                      "void cppUnknown() {}\n"
-                      "#endif");
-  EXPECT_TRUE(InterOp::GetNamed(InterOp::GetSema(I), "cpp17"));
-  EXPECT_FALSE(InterOp::GetNamed(InterOp::GetSema(I), "cppUnknown"));
+  InterOp::Declare("#if __cplusplus==201703L\n"
+                   "int cpp17() { return 2017; }\n"
+                   "#else\n"
+                   "void cppUnknown() {}\n"
+                   "#endif");
+  EXPECT_TRUE(InterOp::GetNamed("cpp17"));
+  EXPECT_FALSE(InterOp::GetNamed("cppUnknown"));
 }

--- a/unittests/InterOp/TypeReflectionTest.cpp
+++ b/unittests/InterOp/TypeReflectionTest.cpp
@@ -68,14 +68,13 @@ TEST(TypeReflectionTest, GetSizeOfType) {
     )";
 
   GetAllTopLevelDecls(code, Decls);
-  Sema *S = &Interp->getCI()->getSema();
 
-  EXPECT_EQ(InterOp::GetSizeOfType(S, InterOp::GetVariableType(Decls[1])), 1);
-  EXPECT_EQ(InterOp::GetSizeOfType(S, InterOp::GetVariableType(Decls[2])), 4);
-  EXPECT_EQ(InterOp::GetSizeOfType(S, InterOp::GetVariableType(Decls[3])), 8);
-  EXPECT_EQ(InterOp::GetSizeOfType(S, InterOp::GetVariableType(Decls[4])), 16);
-  EXPECT_EQ(InterOp::GetSizeOfType(S, InterOp::GetTypeFromScope(Decls[5])), 0);
-  EXPECT_EQ(InterOp::GetSizeOfType(S, InterOp::GetVariableType(Decls[6])), 8);
+  EXPECT_EQ(InterOp::GetSizeOfType(InterOp::GetVariableType(Decls[1])), 1);
+  EXPECT_EQ(InterOp::GetSizeOfType(InterOp::GetVariableType(Decls[2])), 4);
+  EXPECT_EQ(InterOp::GetSizeOfType(InterOp::GetVariableType(Decls[3])), 8);
+  EXPECT_EQ(InterOp::GetSizeOfType(InterOp::GetVariableType(Decls[4])), 16);
+  EXPECT_EQ(InterOp::GetSizeOfType(InterOp::GetTypeFromScope(Decls[5])), 0);
+  EXPECT_EQ(InterOp::GetSizeOfType(InterOp::GetVariableType(Decls[6])), 8);
 }
 
 TEST(TypeReflectionTest, GetCanonicalType) {
@@ -100,9 +99,7 @@ TEST(TypeReflectionTest, GetCanonicalType) {
 }
 
 TEST(TypeReflectionTest, GetType) {
-  Interp.reset(
-      static_cast<compat::Interpreter *>(InterOp::CreateInterpreter()));
-  Sema *S = &Interp->getCI()->getSema();
+  InterOp::CreateInterpreter();
 
   std::string code =  R"(
     class A {};
@@ -110,9 +107,9 @@ TEST(TypeReflectionTest, GetType) {
 
   Interp->declare(code);
 
-  EXPECT_EQ(InterOp::GetTypeAsString(InterOp::GetType(S, "int")), "int");
-  EXPECT_EQ(InterOp::GetTypeAsString(InterOp::GetType(S, "double")), "double");
-  EXPECT_EQ(InterOp::GetTypeAsString(InterOp::GetType(S, "A")), "A");
+  EXPECT_EQ(InterOp::GetTypeAsString(InterOp::GetType("int")), "int");
+  EXPECT_EQ(InterOp::GetTypeAsString(InterOp::GetType("double")), "double");
+  EXPECT_EQ(InterOp::GetTypeAsString(InterOp::GetType("A")), "A");
 }
 
 TEST(TypeReflectionTest, IsRecordType) {
@@ -315,13 +312,11 @@ TEST(TypeReflectionTest, IsUnderlyingTypeRecordType) {
 }
 
 TEST(TypeReflectionTest, GetComplexType) {
-  Interp.reset(
-      static_cast<compat::Interpreter *>(InterOp::CreateInterpreter()));
-  Sema *S = &Interp->getCI()->getSema();
+  InterOp::CreateInterpreter();
 
   auto get_complex_type_as_string = [&](const std::string &element_type) {
-    auto ElementQT = InterOp::GetType(S, element_type);
-    auto ComplexQT = InterOp::GetComplexType(S, ElementQT);
+    auto ElementQT = InterOp::GetType(element_type);
+    auto ComplexQT = InterOp::GetComplexType(ElementQT);
     return InterOp::GetTypeAsString(InterOp::GetCanonicalType(ComplexQT));
   };
 
@@ -369,16 +364,16 @@ TEST(TypeReflectionTest, IsTypeDerivedFrom) {
   InterOp::TCppType_t type_D = InterOp::GetVariableType(Decls[8]);
   InterOp::TCppType_t type_E = InterOp::GetVariableType(Decls[9]);
 
-  EXPECT_TRUE(InterOp::IsTypeDerivedFrom(Interp.get(), type_B, type_A));
-  EXPECT_TRUE(InterOp::IsTypeDerivedFrom(Interp.get(), type_D, type_B));
-  EXPECT_TRUE(InterOp::IsTypeDerivedFrom(Interp.get(), type_D, type_A));
-  EXPECT_TRUE(InterOp::IsTypeDerivedFrom(Interp.get(), type_E, type_A));
+  EXPECT_TRUE(InterOp::IsTypeDerivedFrom(type_B, type_A));
+  EXPECT_TRUE(InterOp::IsTypeDerivedFrom(type_D, type_B));
+  EXPECT_TRUE(InterOp::IsTypeDerivedFrom(type_D, type_A));
+  EXPECT_TRUE(InterOp::IsTypeDerivedFrom(type_E, type_A));
 
-  EXPECT_FALSE(InterOp::IsTypeDerivedFrom(Interp.get(), type_A, type_B));
-  EXPECT_FALSE(InterOp::IsTypeDerivedFrom(Interp.get(), type_C, type_A));
-  EXPECT_FALSE(InterOp::IsTypeDerivedFrom(Interp.get(), type_D, type_C));
-  EXPECT_FALSE(InterOp::IsTypeDerivedFrom(Interp.get(), type_B, type_D));
-  EXPECT_FALSE(InterOp::IsTypeDerivedFrom(Interp.get(), type_A, type_E));
+  EXPECT_FALSE(InterOp::IsTypeDerivedFrom(type_A, type_B));
+  EXPECT_FALSE(InterOp::IsTypeDerivedFrom(type_C, type_A));
+  EXPECT_FALSE(InterOp::IsTypeDerivedFrom(type_D, type_C));
+  EXPECT_FALSE(InterOp::IsTypeDerivedFrom(type_B, type_D));
+  EXPECT_FALSE(InterOp::IsTypeDerivedFrom(type_A, type_E));
 }
 
 TEST(TypeReflectionTest, GetDimensions) {
@@ -478,16 +473,13 @@ TEST(TypeReflectionTest, IsPODType) {
     )";
 
   GetAllTopLevelDecls(code, Decls);
-  Sema *S = &Interp->getSema();
-  EXPECT_TRUE(InterOp::IsPODType(S, InterOp::GetVariableType(Decls[2])));
-  EXPECT_FALSE(InterOp::IsPODType(S, InterOp::GetVariableType(Decls[3])));
-  EXPECT_FALSE(InterOp::IsPODType(S, 0));
+  EXPECT_TRUE(InterOp::IsPODType(InterOp::GetVariableType(Decls[2])));
+  EXPECT_FALSE(InterOp::IsPODType(InterOp::GetVariableType(Decls[3])));
+  EXPECT_FALSE(InterOp::IsPODType(0));
 }
 
 TEST(TypeReflectionTest, IsSmartPtrType) {
-  Interp.reset(
-      static_cast<compat::Interpreter *>(InterOp::CreateInterpreter()));
-  Sema *S = &Interp->getCI()->getSema();
+  InterOp::CreateInterpreter();
 
   Interp->declare(R"(
     #include <memory>
@@ -511,7 +503,7 @@ TEST(TypeReflectionTest, IsSmartPtrType) {
   )");
 
   auto get_type_from_varname = [&](const std::string &varname) {
-    return InterOp::GetVariableType(InterOp::GetNamed(S, varname));
+    return InterOp::GetVariableType(InterOp::GetNamed(varname));
   };
 
   //EXPECT_TRUE(InterOp::IsSmartPtrType(get_type_from_varname("smart_ptr1")));

--- a/unittests/InterOp/Utils.cpp
+++ b/unittests/InterOp/Utils.cpp
@@ -18,20 +18,9 @@
 using namespace clang;
 using namespace llvm;
 
-// Valgrind complains about __cxa_pure_virtual called when deleting
-// llvm::SectionMemoryManager::~SectionMemoryManager as part of the dtor chain
-// of the Interpreter.
-// This might fix the issue https://reviews.llvm.org/D107087
-// FIXME: For now we just leak the Interpreter.
-std::unique_ptr<compat::Interpreter> TestUtils::Interp;
-struct InterpDeleter {
-  ~InterpDeleter() { TestUtils::Interp.release(); }
-} Deleter;
-
 void TestUtils::GetAllTopLevelDecls(const std::string& code, std::vector<Decl*>& Decls,
                                     bool filter_implicitGenerated /* = false */) {
-  Interp.reset(
-      static_cast<compat::Interpreter *>(InterOp::CreateInterpreter()));
+  InterOp::CreateInterpreter();
 #ifdef USE_CLING
   cling::Transaction *T = nullptr;
   Interp->declare(code, &T);
@@ -60,10 +49,10 @@ void TestUtils::GetAllSubDecls(Decl *D, std::vector<Decl*>& SubDecls,
                                bool filter_implicitGenerated /* = false */) {
   if (!isa_and_nonnull<DeclContext>(D))
     return;
-  DeclContext *DC = Decl::castToDeclContext(D);
-  for (auto DCI = DC->decls_begin(), E = DC->decls_end(); DCI != E; ++DCI) {
-    if (filter_implicitGenerated && (*DCI)->isImplicit())
+  DeclContext *DC = cast<DeclContext>(D);
+  for (auto *Di : DC->decls()) {
+    if (filter_implicitGenerated && Di->isImplicit())
       continue;
-    SubDecls.push_back(*DCI);
+    SubDecls.push_back(Di);
   }
 }

--- a/unittests/InterOp/Utils.h
+++ b/unittests/InterOp/Utils.h
@@ -12,14 +12,12 @@ using namespace llvm;
 namespace clang {
   class Decl;
 }
-
+#define Interp (static_cast<compat::Interpreter*>(InterOp::GetInterpreter()))
 namespace TestUtils {
-extern std::unique_ptr<compat::Interpreter> Interp;
-void GetAllTopLevelDecls(const std::string &code,
-                         std::vector<clang::Decl *> &Decls,
-                         bool filter_implicitGenerated = false);
-void GetAllSubDecls(clang::Decl *D, std::vector<clang::Decl *> &SubDecls,
-                    bool filter_implicitGenerated = false);
+  void GetAllTopLevelDecls(const std::string& code, std::vector<clang::Decl*>& Decls,
+                           bool filter_implicitGenerated = false);
+  void GetAllSubDecls(clang::Decl *D, std::vector<clang::Decl*>& SubDecls,
+                      bool filter_implicitGenerated = false);
 } // end namespace TestUtils
 
 #endif // INTEROP_UNITTESTS_LIBINTEROP_UTILS_H

--- a/unittests/InterOp/VariableReflectionTest.cpp
+++ b/unittests/InterOp/VariableReflectionTest.cpp
@@ -53,17 +53,10 @@ TEST(VariableReflectionTest, LookupDatamember) {
     )";
 
   GetAllTopLevelDecls(code, Decls);
-  Sema *S = &Interp->getCI()->getSema();
 
-  EXPECT_EQ(
-      InterOp::GetQualifiedName(InterOp::LookupDatamember(S, "a", Decls[0])),
-      "C::a");
-  EXPECT_EQ(
-      InterOp::GetQualifiedName(InterOp::LookupDatamember(S, "c", Decls[0])),
-      "C::c");
-  EXPECT_EQ(
-      InterOp::GetQualifiedName(InterOp::LookupDatamember(S, "e", Decls[0])),
-      "C::e");
+  EXPECT_EQ(InterOp::GetQualifiedName(InterOp::LookupDatamember("a", Decls[0])), "C::a");
+  EXPECT_EQ(InterOp::GetQualifiedName(InterOp::LookupDatamember("c", Decls[0])), "C::c");
+  EXPECT_EQ(InterOp::GetQualifiedName(InterOp::LookupDatamember("e", Decls[0])), "C::e");
 }
 
 TEST(VariableReflectionTest, GetVariableType) {
@@ -94,48 +87,45 @@ TEST(VariableReflectionTest, GetVariableType) {
   EXPECT_EQ(InterOp::GetTypeAsString(InterOp::GetVariableType(Decls[8])), "int[4]");
 }
 
+#define CODE                                                    \
+  int a;                                                        \
+  const int N = 5;                                              \
+  class C {                                                     \
+  public:                                                       \
+    int a;                                                      \
+    double b;                                                   \
+    int *c;                                                     \
+    int d;                                                      \
+    static int s_a;                                             \
+  } c;                                                            \
+  int C::s_a = 12;
+
+CODE
+
 TEST(VariableReflectionTest, GetVariableOffset) {
   std::vector<Decl *> Decls;
-  std::string code = R"(
-    int a;
-    const int N = 5;
-    class C {
-    public:
-      int a;
-      double b;
-      int *c;
-      int d;
+#define Stringify(s) Stringifyx(s)
+#define Stringifyx(...) #__VA_ARGS__
+  GetAllTopLevelDecls(Stringify(CODE), Decls);
+#undef Stringifyx
+#undef Stringify
+#undef CODE
 
-      static int s_a;
-    };
-    int C::s_a = 12;
-    )";
-
-  class C {
-  public:
-    int a;
-    double b;
-    int *c;
-    int d;
-  } c;
-
-  GetAllTopLevelDecls(code, Decls);
   auto datamembers = InterOp::GetDatamembers(Decls[2]);
 
-  EXPECT_TRUE((bool)InterOp::GetVariableOffset(Interp.get(), Decls[0])); // a
-  EXPECT_TRUE((bool)InterOp::GetVariableOffset(Interp.get(), Decls[1])); // N
+  EXPECT_TRUE((bool) InterOp::GetVariableOffset(Decls[0])); // a
+  EXPECT_TRUE((bool) InterOp::GetVariableOffset(Decls[1])); // N
 
-  EXPECT_EQ(InterOp::GetVariableOffset(Interp.get(), datamembers[0]), 0);
-  EXPECT_EQ(InterOp::GetVariableOffset(Interp.get(), datamembers[1]),
-            ((unsigned long)&(c.b)) - ((unsigned long)&(c.a)));
-  EXPECT_EQ(InterOp::GetVariableOffset(Interp.get(), datamembers[2]),
-            ((unsigned long)&(c.c)) - ((unsigned long)&(c.a)));
-  EXPECT_EQ(InterOp::GetVariableOffset(Interp.get(), datamembers[3]),
-            ((unsigned long)&(c.d)) - ((unsigned long)&(c.a)));
+  EXPECT_EQ(InterOp::GetVariableOffset(datamembers[0]), 0);
+  EXPECT_EQ(InterOp::GetVariableOffset(datamembers[1]),
+          ((unsigned long) &(c.b)) - ((unsigned long) &(c.a)));
+  EXPECT_EQ(InterOp::GetVariableOffset(datamembers[2]),
+          ((unsigned long) &(c.c)) - ((unsigned long) &(c.a)));
+  EXPECT_EQ(InterOp::GetVariableOffset(datamembers[3]),
+          ((unsigned long) &(c.d)) - ((unsigned long) &(c.a)));
 
-  Sema *S = &Interp->getCI()->getSema();
-  auto *VD_C_s_a = InterOp::GetNamed(S, "s_a", Decls[2]); // C::s_a
-  EXPECT_TRUE((bool)InterOp::GetVariableOffset(Interp.get(), VD_C_s_a));
+  auto *VD_C_s_a = InterOp::GetNamed("s_a", Decls[2]); // C::s_a
+  EXPECT_TRUE((bool) InterOp::GetVariableOffset(VD_C_s_a));
 }
 
 TEST(VariableReflectionTest, IsPublicVariable) {


### PR DESCRIPTION
This patch removes the external calls to getInterpreter/getSema in favor of storing them as static variables. That improves the ABI resilience of the API.